### PR TITLE
Keypaths for nested keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,5 @@ module.exports = {
     "no-use-before-define": ["off"],
     "no-return-assign": ["off"],
     "no-param-reassign": ["off"],
-    "no-extra-parens": ["error", "all"],
   },
 };

--- a/README.md
+++ b/README.md
@@ -11,26 +11,13 @@
 
 A **writable** derived store for objects and arrays!
 
-### Objects are `keyed`
-
 ```js
-const name = writable({ first: "Rich", last: "Harris" });
-const firstName = keyed(name, "first");
+const user = writable({ name: { first: "Rich", last: "Harris" } });
+const firstName = keyed(user, "name.first");
 
 $firstName = "Bryan";
 
-console.log($name); // { first: 'Bryan', last: 'Harris' };
-```
-
-### Arrays are `indexed`
-
-```js
-const history = writable(["one", "two", "three"]);
-const previousEdit = indexed(history, 1);
-
-$previousEdit = "four";
-
-console.log($history); // ['one', 'four', 'three'];
+console.log($user); // { name: { first: 'Bryan', last: 'Harris' } };
 ```
 
 ## Installation
@@ -43,27 +30,25 @@ Since Svelte automatically bundles all required dependencies, you only need to i
 
 ## API
 
-`keyed` takes a writable object store and a property name, while `indexed` takes a writable array store and an index value.
-
-Both return a writable store whose **changes are reflected on the original store**.
+`keyed` takes a writable object store and a **keypath**, and returns a writable store whose _changes are reflected on the original store_.
 
 ### Nullable parents
 
 If the parent store is nullable, then the child store will also be nullable.
 
-Due to Typescript limitations, if the parent store is nullable, specify the full type for `keyed` and `indexed`.
-
 ```ts
-const name = writable<Name | undefined>(undefined);
-const firstName = keyed<Name>(name, "first");
+const user = writable<User | undefined>(undefined);
+const firstName = keyed(user, "name.first"); // string | undefined
 ```
 
 ### Nested objects
 
-`keyed` and `indexed` only derive one depth of properties or elements. To access nested objects, nest multiple `keyed` or `indexed` calls.
+To access a nested object, provide a keypath.
+
+Properties are accessed with dot notation, and arrays can be indexed with bracket notation.
 
 ```js
-const email = keyed(indexed(keyed(settings, "profiles"), 0), "email");
+const email = keyed(settings, "profiles[0].email");
 ```
 
 ## Motivations

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "rollup": "^2.61.0",
         "ts-jest": "^27.1.1",
         "tslib": "^2.0.0",
+        "type-fest": "^2.8.0",
         "typescript": "^4.5.2"
       },
       "peerDependencies": {
@@ -3105,6 +3106,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globby": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -5686,12 +5699,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.8.0.tgz",
+      "integrity": "sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8359,6 +8372,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
       }
     },
     "globby": {
@@ -10268,9 +10289,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.8.0.tgz",
+      "integrity": "sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-keyed",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-keyed",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-typescript": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "rollup": "^2.61.0",
     "ts-jest": "^27.1.1",
     "tslib": "^2.0.0",
+    "type-fest": "^2.8.0",
     "typescript": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-keyed",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A writable derived store for objects and arrays",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -168,3 +168,84 @@ describe("shallow keyed array test", () => {
     });
   });
 });
+
+describe("nested keyed object test", () => {
+  let user: User;
+  beforeEach(() => {
+    user = {
+      email: "john@email.com",
+      age: 10,
+      name: { first: "john", last: "smith" },
+    };
+  });
+
+  it("subscribes to the correct value", () => {
+    const parent = writable(user);
+    const firstName = keyed(parent, "name.first");
+    const lastName = keyed(parent, "name.last");
+    expect(get(firstName)).toBe("john");
+    expect(get(lastName)).toBe("smith");
+  });
+
+  it("updates when the parent updates", () => {
+    const parent = writable(user);
+    const firstName = keyed(parent, "name.first");
+    parent.update(($parent) => ({
+      ...$parent,
+      name: {
+        first: "jane",
+        last: "doe",
+      },
+    }));
+    expect(get(firstName)).toBe("jane");
+  });
+
+  it("updates parent when child is updated", () => {
+    const parent = writable(user);
+    const firstName = keyed(parent, "name.first");
+    firstName.update(($firstName) => $firstName.toUpperCase());
+    expect(get(parent)).toStrictEqual({
+      ...user,
+      name: { ...user.name, first: "JOHN" },
+    });
+  });
+
+  it("updates parent when child is set", () => {
+    const parent = writable(user);
+    const firstName = keyed(parent, "name.first");
+    firstName.set("jane");
+    expect(get(parent)).toStrictEqual({
+      ...user,
+      name: { ...user.name, first: "jane" },
+    });
+  });
+
+  describe("undefined", () => {
+    it("handles undefined subscription", () => {
+      const parent = writable<User | undefined>(undefined);
+      const firstName = keyed(parent, "name.first");
+      expect(get(firstName)).toBeUndefined();
+    });
+
+    it("handles undefined parent update", () => {
+      const parent = writable<User | undefined>(undefined);
+      const firstName = keyed(parent, "name.first");
+      parent.update(($parent) => $parent);
+      expect(get(firstName)).toBeUndefined();
+    });
+
+    it("handles undefined parent child update", () => {
+      const parent = writable<User | undefined>(undefined);
+      const firstName = keyed(parent, "name.first");
+      firstName.update(($firstName) => $firstName?.toUpperCase());
+      expect(get(parent)).toBeUndefined();
+    });
+
+    it("handles undefined parent child set", () => {
+      const parent = writable<User | undefined>(undefined);
+      const firstName = keyed(parent, "name.first");
+      firstName.set("jane");
+      expect(get(parent)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Safe types for the derived store are provided by the `Get` type from `type-fest`.